### PR TITLE
feat: add default timeouts to Guzzle Client

### DIFF
--- a/src/PayPalClient.php
+++ b/src/PayPalClient.php
@@ -42,7 +42,11 @@ class PayPalClient implements HttpClient
     public function __construct(Environment $environment)
     {
         $this->environment = $environment;
-        $this->client = new Client(['base_uri' => $environment->baseUrl()]);
+        $this->client = new Client([
+            'base_uri' => $environment->baseUrl(),
+            'timeout' => 30,
+            'connect_timeout' => 10,
+        ]);
         $this->access_token = null;
     }
 


### PR DESCRIPTION
Hi @mohammed-elhaouari,

Thanks for this awesome package.

It is recommended to have timeouts to HTTP clients, recently Laravel has added timeouts to their HTTP client too.

Read more:
* https://divinglaravel.com/always-set-a-timeout-for-guzzle-requests-inside-a-queued-job
* https://github.com/laravel/framework/pull/40466
* https://github.com/laravel/framework/pull/40187

Thanks.