### PR TITLE
Add PHP8.2 to github actions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        php: [ 8.1, 8.0, 7.4 ]
+        php: [ 8.2, 8.1, 8.0, 7.4 ]
         stability: [ prefer-stable ]
 
     name: PHP${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}


### PR DESCRIPTION
php v8.2 will be released on Dec 8, 2022